### PR TITLE
ENH: stats.multivariate_normal: add Covariance class and subclasses

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -488,6 +488,7 @@ from ._rvs_sampling import rvs_ratio_uniforms
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit
+from ._covariance import Covariance, CovViaPrecision, CovViaPSD
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -173,6 +173,11 @@ Multivariate distributions
    multivariate_t         -- Multivariate t-distribution
    multivariate_hypergeom -- Multivariate hypergeometric distribution
 
+   `scipy.stats.multivariate_normal` methods accept an instance of the
+   any one of the following classes to represent the covariance.
+
+   CovViaPrecision        -- Covariance represented via the precision matrix
+
 Discrete distributions
 ----------------------
 
@@ -488,7 +493,7 @@ from ._rvs_sampling import rvs_ratio_uniforms
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 from ._fit import fit
-from ._covariance import Covariance, CovViaPrecision, CovViaPSD
+from ._covariance import CovViaPrecision
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -1,0 +1,142 @@
+from functools import cached_property
+
+import numpy as np
+
+
+__all__ = ["Covariance", "CovViaPrecision", "CovViaPSD"]
+
+
+def _T(A):
+    if A.ndim < 2:
+        return A
+    else:
+        return np.swapaxes(A, -1, -2)
+
+
+def _dot_diag(x, d):
+    # If d were a full diagonal matrix, x @ d would always do what we want
+    # This is for when `d` is compressed to include only the diagonal elements
+    return x * d if x.ndim < 2 else x * np.expand_dims(d, -2)
+
+
+class Covariance():
+    """
+    Representation of a covariance matrix as needed by multivariate_normal
+    """
+    # The last two axes of matrix-like input represent the dimensionality
+    # In the case of diagonal elements or eigenvalues, in which a diagonal
+    # matrix has been reduced to one dimension, the last dimension
+    # of the input represents the dimensionality. Internally, it
+    # will be expanded in the second to last axis as needed.
+    # Matrix math works, but instead of the fundamental matrix-vector
+    # operation being A@x, think of x are row vectors that pre-multiply A.
+
+    def whiten(self, x):
+        """
+        Right multiplication by the left square root of the precision matrix.
+        """
+        return self._whiten(x)
+
+    @cached_property
+    def log_pdet(self):
+        """
+        Log of the pseudo-determinant of the covariance matrix
+        """
+        return np.array(self._log_pdet, dtype=float)[()]
+
+    @cached_property
+    def rank(self):
+        """
+        Rank of the covariance matrix
+        """
+        return np.array(self._rank, dtype=int)[()]
+
+    @cached_property
+    def A(self):
+        """
+        Explicit representation of the covariance matrix
+        """
+        return self._A
+
+    @cached_property
+    def dimensionality(self):
+        """
+        Dimensionality of the vector space
+        """
+        return np.array(self._dimensionality, dtype=int)[()]
+
+    @cached_property
+    def shape(self):
+        """
+        Shape of the covariance array
+        """
+        return self._shape
+
+    def _validate_matrix(self, A, name):
+        A = np.atleast_2d(A)
+        m, n = A.shape[-2:]
+        if m != n or A.ndim != 2 or not np.issubdtype(A.dtype, np.number):
+            message = (f"The input `{name}` must be a square, "
+                       "two-dimensional array of numbers.")
+            raise ValueError(message)
+        return A
+
+    def _validate_vector(self, A, name):
+        A = np.atleast_1d(A)
+        if A.ndim != 1 or not np.issubdtype(A.dtype, np.number):
+            message = (f"The input `{name}` must be a one-dimensional array "
+                       "of numbers.")
+            raise ValueError(message)
+        return A
+
+class CovViaPrecision(Covariance):
+    """
+    Representation of a covariance provided via the precision matrix
+    """
+
+    def __init__(self, precision, covariance=None):
+        precision = self._validate_matrix(precision, 'precision')
+        if covariance is not None:
+            covariance = self._validate_matrix(covariance, 'covariance')
+            message = "`precision.shape` must equal `covariance.shape`."
+            if precision.shape != covariance.shape:
+                raise ValueError(message)
+
+        self._LP = np.linalg.cholesky(precision)
+        self._log_pdet = -2*np.log(np.diag(self._LP)).sum(axis=-1)
+        self._rank = precision.shape[-1]  # must be full rank in invertible
+        self._precision = precision
+        self._covariance = covariance
+        self._dimensionality = self._rank
+        self._shape = precision.shape
+        self._allow_singular = False
+
+    def _whiten(self, x):
+        return x @ self._LP
+
+    @cached_property
+    def _A(self):
+        return (np.linalg.inv(self._precision) if self._covariance is None
+                else self._covariance)
+
+
+class CovViaPSD(Covariance):
+    """
+    Representation of a covariance provided via an instance of _PSD
+    """
+
+    def __init__(self, psd):
+        self._LP = psd.U
+        self._log_pdet = psd.log_pdet
+        self._rank = psd.rank
+        self._A = psd._M
+        self._dimensionality = psd._M.shape[-1]
+        self._shape = psd._M.shape
+        self._psd = psd
+        self._allow_singular = False  # by default
+
+    def _whiten(self, x):
+        return x @ self._LP
+
+    def _support_mask(self, x):
+        return self._psd._support_mask(x)

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -16,7 +16,8 @@ class Covariance():
         """
         Perform a whitening transformation on data.
 
-        "Whitening" transforms a set of random variables into a new set of
+        "Whitening" ("white" as in "white noise", in which each frequency has
+        equal magnitude) transforms a set of random variables into a new set of
         random variable with unit-diagonal covariance. When a whitening
         transform is applied to a sample of points distributed according to
         a multivariate normal distribution with zero mean, the covariance of
@@ -113,7 +114,21 @@ class Covariance():
 
 class CovViaPrecision(Covariance):
     """
-    Representation of a covariance provided via the precision matrix
+    Representation of a covariance provided via its precision matrix.
+
+    Notes
+    -----
+    Let the covariance matrix be :math:`A`, its precision matrix be
+    :math:`P = A^{-1}`, and :math:`L` be the lower Cholesky factor such that
+    :math:`L L^T = P`.
+    Whitening of a data point :math:`x` is performed by computing
+    :math:`x^T L`. :math:`\log\det{A}` is calculated as :math:`-2tr(\log{P})`,
+    where the :math:`\log` operation is performed element-wise.
+
+    This `Covariance` class does not support singular covariance matrices
+    because the precision matrix does not exist for a singular covariance
+    matrix.
+
     """
 
     def __init__(self, precision, covariance=None):
@@ -121,10 +136,13 @@ class CovViaPrecision(Covariance):
         Parameters
         ----------
         precision : array_like
-            The inverse of a square, symmetric, positive definite covariance
-            matrix.
+            The precision matrix; that is, the inverse of a square, symmetric,
+            positive definite covariance matrix.
         covariance : array_like, optional
-            The square, symmetric, positive definite covariance matrix.
+            The square, symmetric, positive definite covariance matrix. If not
+            provided, this may need to be calculated (e.g. to evaluate the
+            cumulative distribution function of
+            `scipy.stats.multivariate_normal`)
         """
         precision = self._validate_matrix(precision, 'precision')
         if covariance is not None:

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -661,7 +661,7 @@ class multivariate_normal_gen(multi_rv_generic):
         x = self._process_quantiles(x, dim)
         if not maxpts:
             maxpts = 1000000 * dim
-        cdf = self._cdf(x, mean, cov_object.A, maxpts, abseps, releps,
+        cdf = self._cdf(x, mean, cov_object.covariance, maxpts, abseps, releps,
                         lower_limit)
         # the log of a negative real is complex, and cdf can be negative
         # if lower limit is greater than upper limit
@@ -706,7 +706,7 @@ class multivariate_normal_gen(multi_rv_generic):
         x = self._process_quantiles(x, dim)
         if not maxpts:
             maxpts = 1000000 * dim
-        out = self._cdf(x, mean, cov_object.A, maxpts, abseps, releps,
+        out = self._cdf(x, mean, cov_object.covariance, maxpts, abseps, releps,
                         lower_limit)
         return out
 
@@ -734,7 +734,8 @@ class multivariate_normal_gen(multi_rv_generic):
         dim, mean, cov_object = self._process_parameters(mean, cov)
 
         random_state = self._get_random_state(random_state)
-        out = random_state.multivariate_normal(mean, cov_object.A, size)
+        out = random_state.multivariate_normal(mean, cov_object.covariance,
+                                               size)
         return _squeeze_output(out)
 
     def entropy(self, mean=None, cov=1):
@@ -836,12 +837,14 @@ class multivariate_normal_frozen(multi_rv_frozen):
 
     def cdf(self, x, *, lower_limit=None):
         x = self._dist._process_quantiles(x, self.dim)
-        out = self._dist._cdf(x, self.mean, self.cov_object.A, self.maxpts,
-                              self.abseps, self.releps, lower_limit)
+        out = self._dist._cdf(x, self.mean, self.cov_object.covariance,
+                              self.maxpts, self.abseps, self.releps,
+                              lower_limit)
         return _squeeze_output(out)
 
     def rvs(self, size=1, random_state=None):
-        return self._dist.rvs(self.mean, self.cov_object.A, size, random_state)
+        return self._dist.rvs(self.mean, self.cov_object.covariance, size,
+                              random_state)
 
     def entropy(self):
         """Computes the differential entropy of the multivariate normal.

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -187,6 +187,7 @@ py3.install_sources([
     '_common.py',
     '_constants.py',
     '_continuous_distns.py',
+    '_covariance.py',
     '_crosstab.py',
     '_discrete_distns.py',
     '_distn_infrastructure.py',

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -26,6 +26,7 @@ from scipy.stats import (multivariate_normal, multivariate_hypergeom,
                          beta, wishart, multinomial, invwishart, chi2,
                          invgamma, norm, uniform, ks_2samp, kstest, binom,
                          hypergeom, multivariate_t, cauchy, normaltest)
+from scipy import stats
 
 from scipy.integrate import romb
 from scipy.special import multigammaln
@@ -33,6 +34,105 @@ from scipy.special import multigammaln
 from .common_tests import check_random_state_property
 
 from unittest.mock import patch
+
+
+class TestCovariance:
+    def test_iv(self):
+        message = "The input `precision` must be a square, two-dimensional..."
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaPrecision(np.ones(2))
+
+        message = "`precision.shape` must equal `covariance.shape`."
+        with pytest.raises(ValueError, match=message):
+            stats.CovViaPrecision(np.eye(3), covariance=np.eye(2))
+
+    def test_mean(self):
+        # test the interaction between a Covariance object and mean
+        P = np.diag(1 / np.array([1, 2, 3]))
+        cov_object = stats.CovViaPrecision(P)
+
+        message = "`cov` represents a covariance matrix in 3 dimensions..."
+        with pytest.raises(ValueError, match=message):
+            multivariate_normal.entropy([0, 0], cov_object)
+
+        x = [0.5, 0.5, 0.5]
+        ref = multivariate_normal.pdf(x, [0, 0, 0], cov_object)
+        assert_equal(multivariate_normal.pdf(x, cov=cov_object), ref)
+
+        ref = multivariate_normal.pdf(x, [1, 1, 1], cov_object)
+        assert_equal(multivariate_normal.pdf(x, 1, cov=cov_object), ref)
+
+    _covariance_preprocessing = {"CovViaPrecision": np.linalg.inv,
+                                 "CovViaPSD": lambda x:
+                                     _PSD(x, allow_singular=True)}
+    _all_covariance_types = np.array(list(_covariance_preprocessing))
+    _matrices = {"diagonal full rank": np.diag([1, 2, 3]),
+                 "general full rank": [[5, 1, 3], [1, 6, 4], [3, 4, 7]],
+                 "diagonal rank-deficient": np.diag([1, 0, 3]),
+                 "general rank-deficient": [[5, -1, 0], [-1, 5, 0], [0, 0, 0]]}
+    _cov_types = {"diagonal full rank": _all_covariance_types,
+                  "general full rank": _all_covariance_types,
+                  "diagonal rank-deficient": _all_covariance_types[[1]],
+                  "general rank-deficient": _all_covariance_types[[1]]}
+
+    @pytest.mark.parametrize("matrix_type", list(_matrices))
+    @pytest.mark.parametrize("cov_type_name", _all_covariance_types)
+    def test_covariance(self, matrix_type, cov_type_name):
+        message = f"{cov_type_name} does not support {matrix_type} matrices"
+        if cov_type_name not in self._cov_types[matrix_type]:
+            pytest.skip(message)
+
+        A = self._matrices[matrix_type]
+        cov_type = getattr(stats, cov_type_name)
+        preprocessing = self._covariance_preprocessing[cov_type_name]
+
+        psd = _PSD(A, allow_singular=True)
+
+        # test properties
+        cov_object = cov_type(preprocessing(A))
+        assert_allclose(cov_object.log_pdet, psd.log_pdet)
+        assert_allclose(cov_object.rank, psd.rank)
+        assert_allclose(cov_object.dimensionality, np.array(A).shape[-1])
+        assert_allclose(cov_object.A, A)
+
+        # test whitening 1D x
+        rng = np.random.default_rng(5292808890472453840)
+        x = rng.random(size=3)
+        res = cov_object.whiten(x)
+        ref = x @ psd.U
+        assert_allclose(res @ res, ref @ ref)
+
+        # test whitening 3D x
+        x = rng.random(size=(2, 4, 3))
+        res = cov_object.whiten(x)
+        ref = x @ psd.U
+        assert_allclose((res**2).sum(axis=-1), (ref**2).sum(axis=-1))
+
+    @pytest.mark.parametrize("matrix_type", list(_matrices))
+    @pytest.mark.parametrize("cov_type_name", _all_covariance_types)
+    def test_mvn_with_covariance(self, matrix_type, cov_type_name):
+        message = f"{cov_type_name} does not support {matrix_type} matrices"
+        if cov_type_name not in self._cov_types[matrix_type]:
+            pytest.skip(message)
+
+        A = self._matrices[matrix_type]
+        cov_type = getattr(stats, cov_type_name)
+        preprocessing = self._covariance_preprocessing[cov_type_name]
+
+        mean = [0.1, 0.2, 0.3]
+        cov_object = cov_type(preprocessing(A))
+        mvn = multivariate_normal
+        dist0 = multivariate_normal(mean, A, allow_singular=True)
+        dist1 = multivariate_normal(mean, cov_object, allow_singular=True)
+
+        rng = np.random.default_rng(5292808890472453840)
+        x = rng.multivariate_normal(mean, A, size=(2, 4, 3))
+        assert_allclose(mvn.pdf(x, mean, cov_object), dist0.pdf(x))
+        assert_allclose(dist1.pdf(x), dist0.pdf(x))
+        assert_allclose(mvn.logpdf(x, mean, cov_object), dist0.logpdf(x))
+        assert_allclose(dist1.logpdf(x), dist0.logpdf(x))
+        assert_allclose(mvn.entropy(mean, cov_object), dist0.entropy())
+        assert_allclose(dist1.entropy(), dist0.entropy())
 
 
 def _sample_orthonormal_matrix(n):
@@ -132,7 +232,7 @@ class TestMultivariateNormal:
             s = np.random.randn(n, expected_rank)
             cov = np.dot(s, s.T)
             distn = multivariate_normal(mean, cov, allow_singular=True)
-            assert_equal(distn.cov_info.rank, expected_rank)
+            assert_equal(distn.cov_object.rank, expected_rank)
 
     def test_degenerate_distributions(self):
 
@@ -163,9 +263,9 @@ class TestMultivariateNormal:
                                                allow_singular=True)
                 distn_rr = multivariate_normal(np.zeros(n), cov_rr,
                                                allow_singular=True)
-                assert_equal(distn_kk.cov_info.rank, k)
-                assert_equal(distn_nn.cov_info.rank, k)
-                assert_equal(distn_rr.cov_info.rank, k)
+                assert_equal(distn_kk.cov_object.rank, k)
+                assert_equal(distn_nn.cov_object.rank, k)
+                assert_equal(distn_rr.cov_object.rank, k)
                 pdf_kk = distn_kk.pdf(x[:k])
                 pdf_nn = distn_nn.pdf(x)
                 pdf_rr = distn_rr.pdf(y)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -26,7 +26,7 @@ from scipy.stats import (multivariate_normal, multivariate_hypergeom,
                          beta, wishart, multinomial, invwishart, chi2,
                          invgamma, norm, uniform, ks_2samp, kstest, binom,
                          hypergeom, multivariate_t, cauchy, normaltest)
-from scipy import stats
+from scipy.stats import _covariance
 
 from scipy.integrate import romb
 from scipy.special import multigammaln
@@ -45,11 +45,11 @@ class TestCovariance:
     def test_input_validation(self):
         message = "The input `precision` must be a square, two-dimensional..."
         with pytest.raises(ValueError, match=message):
-            stats.CovViaPrecision(np.ones(2))
+            _covariance.CovViaPrecision(np.ones(2))
 
         message = "`precision.shape` must equal `covariance.shape`."
         with pytest.raises(ValueError, match=message):
-            stats.CovViaPrecision(np.eye(3), covariance=np.eye(2))
+            _covariance.CovViaPrecision(np.eye(3), covariance=np.eye(2))
 
     _covariance_preprocessing = {"CovViaPrecision": np.linalg.inv,
                                  "CovViaPSD": lambda x:
@@ -72,7 +72,7 @@ class TestCovariance:
             pytest.skip(message)
 
         A = self._matrices[matrix_type]
-        cov_type = getattr(stats, cov_type_name)
+        cov_type = getattr(_covariance, cov_type_name)
         preprocessing = self._covariance_preprocessing[cov_type_name]
 
         psd = _PSD(A, allow_singular=True)
@@ -108,7 +108,7 @@ class TestCovariance:
             pytest.skip(message)
 
         A = self._matrices[matrix_type]
-        cov_type = getattr(stats, cov_type_name)
+        cov_type = getattr(_covariance, cov_type_name)
         preprocessing = self._covariance_preprocessing[cov_type_name]
 
         mean = [0.1, 0.2, 0.3]
@@ -142,7 +142,7 @@ class TestCovariance:
         # provide the `covariance` attribute.
         matrix_type = "diagonal full rank"
         A = self._matrices[matrix_type]
-        cov_type = getattr(stats, cov_type_name)
+        cov_type = getattr(_covariance, cov_type_name)
         preprocessing = self._covariance_preprocessing[cov_type_name]
 
         mean = [0.1, 0.2, 0.3]
@@ -674,7 +674,7 @@ class TestMultivariateNormal:
     def test_mean_cov(self):
         # test the interaction between a Covariance object and mean
         P = np.diag(1 / np.array([1, 2, 3]))
-        cov_object = stats.CovViaPrecision(P)
+        cov_object = _covariance.CovViaPrecision(P)
 
         message = "`cov` represents a covariance matrix in 3 dimensions..."
         with pytest.raises(ValueError, match=message):


### PR DESCRIPTION
We discussed removing `inverse_cov` and instead having a class representing a covariance via the precision matrix that could be passed into the old `cov` argument. The addition of `inverse_cov` touched pretty much everything, so I decided to revert the files back to main in 1272690e06a7d42b3c25f65c70f126f8a0322ff8, then re-apply changes that we want to keep in 9129594b149c3251ce68267af3664dfb5f17aa2f to make it easier to review. I'd suggest looking only at the changes between the two commits, since I think that will make it easier to see how the changes really work.

I think there are still some things you wrote that we might want to bring back here. Please take a look at my tests and then at the tests you added in scipy/scipy#16002 to see which of those you think should be included in some form.